### PR TITLE
test: StepVerifier 기반 JWT 필터 리액티브 테스트 추가

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,3 +33,11 @@ jobs:
           name: test-report
           path: build/reports/tests/test/
           retention-days: 7
+      - name: Generate coverage report
+        run: ./gradlew jacocoTestReport --console=plain
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ is tracked as GitHub issues **in this repo**, not as repo-less Draft cards on th
 
 ---
 
-<!-- canon:begin sha=2327991ef5aa src=~/msa/AGENTS.md -->
+<!-- canon:begin sha=7ab837cdce2d src=~/msa/AGENTS.md -->
 ## 공통 캐논 (모든 AI 도구 공통)
 
 > **공통 캐논 (자동 주입 — 손으로 고치지 말 것).** 원본은 `~/msa/AGENTS.md`이고 이 블록은
@@ -195,6 +195,14 @@ is tracked as GitHub issues **in this repo**, not as repo-less Draft cards on th
 - **모든 상태 변경(쓰기) API는 멱등해야 한다.** 재시도/중복 호출이 이중 차감·이중 결제가 되지 않게 멱등성 키(예: orderId) 기반 dedup을 넣는다 (posselect #211).
 - 클래스 레벨 `@Transactional(readOnly = true)`인 클래스에 쓰기 경로 추가 금지 — 전파 함정으로 UPDATE가 조용히 사라진다. 쓰기는 별도 클래스 또는 `REQUIRES_NEW` (posselect #211 롤백 사례).
 - **트랜잭션 전파·멱등성 변경은 단위 테스트로 검증이 성립하지 않는다.** 실제 DB 상태 변화 실측(같은 키로 2회 호출 → 1회만 반영)으로 검증하고, 실측 후 데이터 원복까지 한 세트로 수행 (posselect #211).
+
+### TDD / AI 에이전트 테스트 프로토콜
+- 새 기능·버그 수정은 가능한 범위에서 **실패하는 테스트 먼저 작성 → 통과하도록 구현 → 리팩터링** 순서로 진행한다. 순수 설정/인프라 변경처럼 테스트로 표현되지 않는 작업은 예외.
+- Test Pyramid: Unit(JUnit5/Vitest, 가장 많이) → Integration(Testcontainers 실DB, 서비스 경계 검증) → E2E(Playwright, 핵심 플로우만 적게). 계층별 책임과 저장소별 현황은 `architecture` 저장소 `docs/2026-08-21-test-pyramid-strategy.md` 참고.
+- **위 "트랜잭션 / 정합성" 절의 예외가 여기도 그대로 적용된다** — 트랜잭션 전파·멱등성 변경은 단위 테스트로 검증이 성립하지 않으므로 실제 DB 상태 실측으로 검증한다.
+- **커버리지는 리포트만 하고 게이트로 쓰지 않는다(2026-08-21 결정).** 대부분 저장소가 0%에서 시작해 즉시 임계값을 걸면 모든 PR이 막힌다 — CI가 커버리지를 아티팩트로 남기고, 수치가 쌓이면 추후 임계값 도입을 재검토한다.
+- 기존 테스트가 있는 저장소는 `verify.sh`(§5-1)가 이미 push 전 실행을 강제한다 — 새 테스트를 추가하는 순간부터 자동으로 강제 대상이 된다. 별도 CI 배선이 필요 없다.
+- 근거: architecture#14(장기 개선, TDD 도입), posselect-shell#26(Testcontainers 통합 테스트 표준, posselect #211 readOnly 전파 롤백 사례에서 도출).
 
 ### 보안 / 인가
 - **사용자 식별 키는 Keycloak sub(`X-User-Id`)만.** 이메일은 변경 가능하므로 소유자 키로 쓰지 않는다 (posselect #210).

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.7'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.dh'
@@ -31,6 +32,7 @@ dependencies {
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
@@ -42,4 +44,8 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacocoTestReport {
+	dependsOn test
 }

--- a/src/test/java/com/dh/gateway/security/JwtAuthenticationFilterReactiveTest.java
+++ b/src/test/java/com/dh/gateway/security/JwtAuthenticationFilterReactiveTest.java
@@ -1,0 +1,65 @@
+package com.dh.gateway.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@link JwtAuthenticationFilter}를 StepVerifier로 검증하는 테스트.
+ *
+ * 기존 {@link JwtAuthenticationFilterPublicPathTest}는 쿠키가 아예 없는 경우(공개 경로 통과/보호
+ * 경로 302)만 다루고 {@code .block()}으로 동기 처리한다. 여기서는 쿠키는 있지만 서명 검증에 실패하는
+ * 경로(파싱 자체가 안 되는 값, verify()의 onErrorResume 분기)를 필터가 반환하는 Mono<Void> 자체를
+ * StepVerifier로 구독해 검증하고, 응답 상태는 구독 완료 후에 확인한다. GatewayFilterChain은
+ * Mockito 목으로 대체해 체인 자체는 실행되지 않게 한다.
+ */
+class JwtAuthenticationFilterReactiveTest {
+
+    private static final String PROTECTED_HOST = "customer.posselect.com";
+
+    private JwtAuthenticationFilter filter;
+    private GatewayFilterChain chain;
+
+    @BeforeEach
+    void setUp() {
+        GatewaySecurityProperties properties = new GatewaySecurityProperties();
+        properties.setProtectedHosts(List.of(PROTECTED_HOST));
+        properties.setLoginUrl("https://" + PROTECTED_HOST + "/login");
+        properties.setKeycloakIssuer("https://keycloak.posselect.com/realms/customer");
+        filter = new JwtAuthenticationFilter(WebClient.builder(), properties);
+        chain = mock(GatewayFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+    }
+
+    @Test
+    void 보호_경로에서_형식이_깨진_JWT_쿠키는_체인을_타지_않고_로그인으로_302된다() {
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("https://" + PROTECTED_HOST + "/mypage")
+                        .header("Cookie", "ACCESS_TOKEN=not-a-valid-jwt"));
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
+        assertThat(exchange.getResponse().getHeaders().getLocation())
+                .hasToString("https://" + PROTECTED_HOST + "/login?redirect_uri="
+                        + "https%3A%2F%2F" + PROTECTED_HOST + "%2Fmypage");
+        verify(chain, never()).filter(any());
+    }
+}


### PR DESCRIPTION
## 요약
- WebFlux 스택인데 reactor-test/StepVerifier 관용구가 전혀 없던 갭을 메운다.
- 기존 유일한 실질 테스트(JwtAuthenticationFilterPublicPathTest)는 Mono를 .block()으로 동기 처리해서 검증했음.
- JwtAuthenticationFilterReactiveTest 신규 추가: 보호 경로에서 형식이 깨진 JWT 쿠키가 왔을 때 체인을 타지 않고 StepVerifier로 구독한 Mono<Void>가 정상 완료되며 302 리다이렉트되는지 검증(기존 테스트가 다루지 않던, "쿠키는 있지만 검증 실패" 경로).
- build.gradle: reactor-test 테스트 의존성 + jacoco 플러그인(리포트 전용, 커버리지 게이트 아님).
- pr-check.yml: 테스트 후 jacocoTestReport 실행 + HTML 리포트 아티팩트 업로드 단계 추가.
- AGENTS.md: ~/msa/AGENTS.md의 새 TDD/에이전트 테스트 프로토콜 캐논 섹션 동기화.

라우팅/JWT 검증 로직 자체는 건드리지 않았다(테스트·CI·문서 전용 변경).

## 관련 이슈
Closes #219
Ref architecture#14 (TDD 도입 및 Test Pyramid 전략 수립)

## 테스트
- ./gradlew test --console=plain 로컬 통과
- ./gradlew jacocoTestReport --console=plain 로컬 통과, build/reports/jacoco/test/html 생성 확인