### PR TITLE
chore: coffee.posselect.com 오생성 잔재 제거 (#233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Spring Cloud Gateway (WebFlux/Netty) reverse proxy that is the **single entry point for every domain on
 this cluster** — both the `leedohyun.com` family (tool, blog/wordpress, minio, architecture, router admin)
-and the `posselect.com` shopping mall family (customer / home / www / product / admin / coffee fronts,
+and the `posselect.com` shopping mall family (customer / home / www / product / admin fronts,
 their APIs, keycloak, grafana, imgproxy/CDN, the design-system and shell static sites). Nothing reaches a
 backend without passing through here.
 
@@ -51,7 +51,7 @@ gone and must not be reintroduced.
     to `www.posselect.com`.
   - `posselect.com` family: `customer` (auth-api, order-api, customer-front), `home`+`www` (auth-api,
     store-front), `product` (product-api, order-api, auth-api addresses, product-front), `admin`,
-    `coffee`, `keycloak`, `monitoring` (grafana), `ui`+`storybook`, `shell`, `static`, `image`
+    `keycloak`, `monitoring` (grafana), `ui`+`storybook`, `shell`, `static`, `image`
     (cdn-alias for `/cdn/**`, imgproxy otherwise).
 - **Route order is load-bearing.** Spring Cloud Gateway matches in declaration order, and three patterns
   in this file depend on it:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ leedohyun.com / posselect.com 클러스터의 **단일 진입점**. Spring Cloud
 ## 역할
 
 - **모든 도메인이 여기를 지난다.** `leedohyun.com` 계열(tool, blog/wordpress, minio, architecture,
-  router 관리 UI)과 `posselect.com` 쇼핑몰 계열(customer / home / www / product / admin / coffee 프론트와
+  router 관리 UI)과 `posselect.com` 쇼핑몰 계열(customer / home / www / product / admin 프론트와
   각 API, keycloak, grafana, imgproxy·CDN, 디자인 시스템/셸 정적 사이트)을 호스트 프리디케이트로 분기한다.
   구 `*.leedohyun.com` 쇼핑몰 호스트는 프록시가 아니라 `*.posselect.com`으로 302 리다이렉트한다.
 - **인증은 이 저장소에서만 강제된다.** `JwtAuthenticationFilter`(GlobalFilter)가 `ACCESS_TOKEN` 쿠키의

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -172,17 +172,6 @@ spring:
             predicates:
             - Host=home.posselect.com,www.posselect.com
             uri: http://store-front.customer.svc.cluster.local:3000
-         -  id: coffee-front-block-write
-            predicates:
-            - Host=coffee.posselect.com
-            - Method=POST,PUT,PATCH,DELETE
-            filters:
-            - SetStatus=403
-            uri: no://op
-         -  id: coffee-front
-            predicates:
-            - Host=coffee.posselect.com
-            uri: http://coffee-front.customer.svc.cluster.local:3000
          -  id: product-api
             predicates:
             - Host=product.posselect.com


### PR DESCRIPTION
Closes #233

## 무엇

`coffee.posselect.com` 은 **오류로 생성된 호스트**라 되살리지 않고 제거한다.

- `application.yml` — `coffee-front-block-write`, `coffee-front` 라우트 2개 삭제
- `README.md`, `AGENTS.md` — 도메인 나열에서 coffee 제거 (자동 주입 캐논 블록 바깥)

## 왜 지금까지 404 였나

`~/msa/posselect-com-ingress.yaml` 의 `spec.rules` / `spec.tls[0].hosts` 어디에도 이 호스트가 없다. Traefik 이 애초에 게이트웨이로 넘기지 않으니 위 라우트 2개는 **도달 불가**였다.

되살릴 수도 없다 — 백엔드가 존재한 적 없다:

```
$ kubectl get all -A | grep -i coffee
(0건)
```

`customer` 네임스페이스에 `coffee-front` Service/Deployment 가 없고, 로컬에 `coffee.front` 저장소도 없다. 즉 Ingress 를 추가해도 붙을 대상이 없으므로 설정만 지우는 것이 맞다.

## 검증

- YAML 파싱: 라우트 37개, 중복 id 없음, 선언 순서 유지(`store-front-block-write` → `store-front` → `product-api`)
- `scripts/verify.sh` 통과 (로컬 + pre-push 훅)
- 저장소 내 `coffee` 문자열 잔여 0건

## 남은 작업 (이 PR 밖)

`~/msa/customer/networkpolicy.yaml` 의 `allow-fronts` 셀렉터에도 `coffee-front` 가 남아 있다. ~/msa 는 git 저장소가 아니라 별도로 처리한다(존재하지 않는 파드라 기능적으로는 no-op).

## 배포 영향

`main` 머지 = 즉시 프로덕션 배포. 삭제되는 라우트는 도달 불가였으므로 살아있는 트래픽에 영향 없음. Ingress 는 건드리지 않는다(와일드카드 인증서 사고 방지).