### PR TITLE
feat(route): tool.posselect.com 개발자 도구 모음 라우트 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,14 @@ spring:
             predicates:
             - Host=tool.leedohyun.com
             uri: http://tool-service.tool.svc.cluster.local:80
+         # tool.posselect.com = PosSelect 개발자 도구 모음 (저장소 lee-dohyun/tool.front).
+         # 위 tool.leedohyun.com(개인 유틸 사이트)과 같은 네임스페이스에 있지만 별개 서비스다 —
+         # 백엔드 Service 이름이 다르므로 두 라우트를 합치지 말 것.
+         # 인증 없음(공개): protected-hosts 에 넣지 않는다. 링크되는 도구들은 각자 자체 로그인이 있다.
+         -  id: posselect-tool
+            predicates:
+            - Host=tool.posselect.com
+            uri: http://posselect-tool-service.tool.svc.cluster.local:80
          -  id: root-redirect
             predicates:
             - Host=leedohyun.com,www.leedohyun.com


### PR DESCRIPTION
PosSelect 개발자 도구 모음 사이트(`lee-dohyun/tool.front`)를 게이트웨이에 연결한다.

- 백엔드: `posselect-tool-service.tool.svc.cluster.local:80`
- 같은 `tool` 네임스페이스의 기존 `tool.leedohyun.com`(개인 유틸 사이트)과는 **별개 서비스**다
- 인증 없음(공개) — `protected-hosts` 미등록. 사용자 확인 완료(2026-08-22)

## 선행 완료
- `~/msa/posselect-com-ingress.yaml` 에 host + tls.hosts 추가 후 apply 완료 (와일드카드 인증서 `CN=*.posselect.com` 무사 확인)
- `tool` 네임스페이스에 `posselect-tool` Deployment/Service 생성 완료

## 검증
- `scripts/verify.sh` (gradlew test) 통과
- application.yml YAML 파싱 확인 — 라우트 38개, `tool` / `posselect-tool` 두 라우트가 서로 다른 백엔드를 가리킴

Refs lee-dohyun/tool.front#1